### PR TITLE
Update to the latest zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -52,11 +52,11 @@ pub fn build(b: *std.Build) void {
     const include_wf = b.addNamedWriteFiles("include");
 
     const hdrgen_step = b.addRunArtifact(hdrgen);
-    hdrgen_step.addDirectorySourceArg(.{ .generated = .{
+    hdrgen_step.addDirectoryArg(.{ .generated = .{
         .file = &include_wf.generated_directory,
     } });
 
-    hdrgen_step.addDirectorySourceArg(b.path("include"));
+    hdrgen_step.addDirectoryArg(b.path("include"));
 
     const libdir_wf = b.addWriteFiles();
 
@@ -74,11 +74,11 @@ pub fn build(b: *std.Build) void {
                     .minor = 0,
                     .patch = 0,
                 } else null,
-                .root_module = .{
+                .root_module = b.createModule(.{
                     .target = target,
                     .optimize = optimize,
                     .root_source_file = b.path("lib/nulibc.zig"),
-                },
+                }),
             });
 
             lib.no_builtin = true;

--- a/build/Options.zig
+++ b/build/Options.zig
@@ -136,6 +136,40 @@ pub fn make(options: Options, b: *std.Build) *std.Build.Step.Options {
 
                 linux.android,
             }) catch @panic("OOM"),
+            .hurd => |hurd| step.contents.writer().print(
+                \\ .hurd = .{{
+                \\        .range = .{{
+                \\            .min = .{{
+                \\                .major = {},
+                \\                .minor = {},
+                \\                .patch = {},
+                \\            }},
+                \\            .max = .{{
+                \\                .major = {},
+                \\                .minor = {},
+                \\                .patch = {},
+                \\            }},
+                \\        }},
+                \\        .glibc = .{{
+                \\            .major = {},
+                \\            .minor = {},
+                \\            .patch = {},
+                \\        }},
+                \\    }}}},
+                \\
+            , .{
+                hurd.range.min.major,
+                hurd.range.min.minor,
+                hurd.range.min.patch,
+
+                hurd.range.max.major,
+                hurd.range.max.minor,
+                hurd.range.max.patch,
+
+                hurd.glibc.major,
+                hurd.glibc.minor,
+                hurd.glibc.patch,
+            }) catch @panic("OOM"),
             .windows => |windows| step.contents.writer().print(
                 \\ .windows = .{{
                 \\        .min = {c},

--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735328357,
-        "narHash": "sha256-kD91N+MRvTEkAzJrU7CEhmQ/b9p3OiHQ8JRK4GDHSXg=",
+        "lastModified": 1739769471,
+        "narHash": "sha256-D76RvRtaCMOPjtLZUZlFpOSS6EhgwVsbp+Y/ypUuo1g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e45f8499ce642df75a3911aa73a18142a8d14437",
+        "rev": "557cff025b95b3399d4cf14cc2bacaa7788007ff",
         "type": "github"
       },
       "original": {
@@ -80,32 +80,31 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
     "zig": {
       "flake": false,
       "locked": {
-        "lastModified": 1730636074,
-        "narHash": "sha256-OKT12XooLZlJ42nycBHV2zhX7DcNz2k83wsh2s0rfdQ=",
+        "lastModified": 1739766491,
+        "narHash": "sha256-lQzii/iXlTguW4dKm636G7ip+0VwxyGSoA6Na6RmH+c=",
         "owner": "ziglang",
         "repo": "zig",
-        "rev": "f539f9f74c3ff6f6083ecb5c99e074eee562d218",
+        "rev": "d7b93c78769360c954a364613c1c1b382020da0a",
         "type": "github"
       },
       "original": {
         "owner": "ziglang",
-        "ref": "pull/20511/head",
         "repo": "zig",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    systems.url = "github:nix-systems/default-linux";
+    systems.url = "github:nix-systems/default";
     flake-utils.url = "github:numtide/flake-utils";
     zig = {
-      url = "github:ziglang/zig?ref=pull/20511/head";
+      url = "github:ziglang/zig";
       flake = false;
     };
     zon2nix = {

--- a/lib/nulibc/start.zig
+++ b/lib/nulibc/start.zig
@@ -56,7 +56,7 @@ pub fn startMain(argc: usize, argv: [*][*:0]u8, envp: [*][*:0]u8, envp_count: us
             // ARMv6 targets (and earlier) have no support for TLS in hardware.
             // FIXME: Elide the check for targets >= ARMv7 when the target feature API
             // becomes less verbose (and more usable).
-            if (comptime native_arch.isARM()) {
+            if (comptime native_arch.isArm()) {
                 if (at_hwcap & std.os.linux.HWCAP.TLS == 0) {
                     // FIXME: Make __aeabi_read_tp call the kernel helper kuser_get_tls
                     // For the time being use a simple trap instead of a @panic call to
@@ -106,7 +106,7 @@ fn expandStackSize(phdrs: []std.elf.Phdr) void {
         switch (phdr.p_type) {
             std.elf.PT_GNU_STACK => {
                 if (phdr.p_memsz == 0) break;
-                assert(phdr.p_memsz % std.heap.pageSize() == 0);
+                assert(phdr.p_memsz % std.heap.page_size_min == 0);
 
                 // Silently fail if we are unable to get limits.
                 const limits = std.posix.getrlimit(.STACK) catch break;


### PR DESCRIPTION
I also switched systems.url to use default instead of default-linux so I could `nix develop` -> `zig build -Dlinkage=dynamic -Dtarget=aarch64-linux` on MacOS but also to investigate darwin startup support (not sure if this would be accepted).

This PR also seems to fix the Garnix checks.